### PR TITLE
Match all service monitor 

### DIFF
--- a/mycluster/prometheus/helm-release.yaml
+++ b/mycluster/prometheus/helm-release.yaml
@@ -23,6 +23,10 @@ spec:
     global:
       rbac:
         pspEnabled: false
+    prometheus:
+      prometheusSpec:
+        # Disable in order to match servicemonitor created from other helm charts
+        serviceMonitorSelectorNilUsesHelmValues: false
     grafana:
       service:
         type: LoadBalancer


### PR DESCRIPTION
By default,  serviceMonitorSelector is set to match `release: ReleaseName` upon helm install.
This will remove that and select all serviceMonitor